### PR TITLE
Update `grunt` in the `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
 		"grunt-util-property": "~0.0.1"
 	},
 	"peerDependencies": {
-		"grunt": "~0.4.1"
+		"grunt": ">=0.4.1"
 	}
 }


### PR DESCRIPTION
https://github.com/gruntjs/grunt/blob/master/CHANGELOG
 - if you have a Grunt plugin that includes `grunt` in the `peerDependencies`, we recommend tagging with `"grunt": "">= 0.4.0"` and publishing a new version on npm.